### PR TITLE
make tests verbose

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,6 @@ jobs:
         with:
           command: uv run --frozen --no-dev --exact
       - name: Run unit tests
-        run: uv run --frozen python -m pytest
+        run: uv run --frozen python -m pytest -v
       - name: Run doctests
-        run: uv run --frozen python -m pytest --doctest-modules ${{ inputs.src_dir }}
+        run: uv run --frozen python -m pytest -v --doctest-modules ${{ inputs.src_dir }}


### PR DESCRIPTION
This pull request makes a minor update to the test workflow configuration by enabling verbose output for both unit tests and doctests. This will provide more detailed information in test logs, making it easier to diagnose test failures.

* Test workflow updates:
  * Modified the unit test and doctest commands in `.github/workflows/tests.yml` to include the `-v` (verbose) flag for `pytest`, resulting in more detailed test output.