### PR TITLE
optional port audio setup

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,11 @@ on:
         type: string
         required: false
         default: ${{ github.event.repository.name }}
+      setup_portaudio:
+        description: 'Whether PortAudio should be installed.'
+        type: boolean
+        required: false
+        default: true
 
 concurrency:
   group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -26,6 +31,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
       - name: Set up PortAudio
+        if: ${{ inputs.setup_portaudio }}
         uses: acoular/ci/.github/actions/setup-portaudio@main
       - name: Generate coverage report
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: ''
         type: string
+      setup_portaudio:
+        description: 'Whether PortAudio should be installed.'
+        type: boolean
+        required: false
+        default: true
 
 concurrency:
   group: docs-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -36,6 +41,7 @@ jobs:
         with:
           os: ${{ matrix.os }}
       - name: Set up PortAudio
+        if: ${{ inputs.setup_portaudio }}
         uses: acoular/ci/.github/actions/setup-portaudio@main
         with:
           os: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,11 @@ on:
         type: string
         required: false
         default: ${{ github.event.repository.name }}
+      setup_portaudio:
+        description: 'Whether PortAudio should be installed.'
+        type: boolean
+        required: false
+        default: true
 
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -28,6 +33,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up PortAudio
+        if: ${{ inputs.setup_portaudio }}
         uses: acoular/ci/.github/actions/setup-portaudio@main
         with:
           os: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 - The workflows assumes that there exists a repository variable `SUPPORTED_PYTHON_VERSIONS` with value `["3.10", "3.11", "3.12", "3.13"]` and `LATEST_PYTHON_VERSION` with value `3.13` or similar that lists the supported Python versions of the package. **Note**: need to use double quotes for the array and no quotes for a single version.
 - These are configured as organizational variables so do not need to be set explicitly. However, they can be overriden by setting them in the repository or environment scope.
 
+## PortAudio
+- The `tests`, `docs`, and `coverage` reusable workflows install PortAudio by default.
+- Repositories that do not need PortAudio can disable this setup with the optional `setup_portaudio` input:
+
+```yaml
+jobs:
+  tests:
+    uses: acoular/ci/.github/workflows/tests.yml@main
+    with:
+      src_dir: acoupipe
+      setup_portaudio: false
+```
+
 ## Permissions
 - Permissions are set *restrictive* for the entire organization. This means that specific permissions need to be configured for every workflow.
 - **Only** define permissions in `workflow.yml` if it is really necessary. E.g., `contents: read` is the default and not needed. Defining this would make it cumbersome to change defaults. Nonetheless, we add a `contents: read` block to the top of each workflow to keep CodeQL happy and doubly enforce least priviledge.

--- a/README.md
+++ b/README.md
@@ -4,19 +4,6 @@
 - The workflows assumes that there exists a repository variable `SUPPORTED_PYTHON_VERSIONS` with value `["3.10", "3.11", "3.12", "3.13"]` and `LATEST_PYTHON_VERSION` with value `3.13` or similar that lists the supported Python versions of the package. **Note**: need to use double quotes for the array and no quotes for a single version.
 - These are configured as organizational variables so do not need to be set explicitly. However, they can be overriden by setting them in the repository or environment scope.
 
-## PortAudio
-- The `tests`, `docs`, and `coverage` reusable workflows install PortAudio by default.
-- Repositories that do not need PortAudio can disable this setup with the optional `setup_portaudio` input:
-
-```yaml
-jobs:
-  tests:
-    uses: acoular/ci/.github/workflows/tests.yml@main
-    with:
-      src_dir: acoupipe
-      setup_portaudio: false
-```
-
 ## Permissions
 - Permissions are set *restrictive* for the entire organization. This means that specific permissions need to be configured for every workflow.
 - **Only** define permissions in `workflow.yml` if it is really necessary. E.g., `contents: read` is the default and not needed. Defining this would make it cumbersome to change defaults. Nonetheless, we add a `contents: read` block to the top of each workflow to keep CodeQL happy and doubly enforce least priviledge.
@@ -34,3 +21,17 @@ Environments are hardcoded. Currently, there are
 ## Deployment
 - **PyPI** and TestPyPI deployments use [trusted publishing](https://docs.pypi.org/trusted-publishers/). This means that we do not need a secret or token in GitHub. Instead, we configure a specific GitHub environment as trusted source on the PyPI side. If we select this environment in the GitHub workflow, short-lived access tokens will be generated on demand automatically.
 - **Anaconda** uses an access token. The token needs to be generated on the [Anaconda website or CLI](https://www.anaconda.com/docs/tools/anaconda-org/admin-guide/tokens) (scope: "Allow all operations on Conda repositories"). It is *not* added as an organizational secret but as an environment secret to each repository. This token has en expiration date and needs to be renewed yearly.
+
+## PortAudio
+- The `tests`, `docs`, and `coverage` reusable workflows install PortAudio by default.
+- Repositories that do not need PortAudio can disable this setup with the optional `setup_portaudio` input:
+
+```yaml
+jobs:
+  tests:
+    uses: acoular/ci/.github/workflows/tests.yml@main
+    with:
+      src_dir: acoupipe
+      setup_portaudio: false
+```
+


### PR DESCRIPTION
This pull request introduces a configurable option to control whether PortAudio is installed in the `tests`, `docs`, and `coverage` GitHub workflows. By default, PortAudio will be installed, but repositories can now opt out by setting the new `setup_portaudio` input to `false`. This is especially relevant for the AcouPipe package which does not require the sounddevice package.

**Workflow configuration improvements:**

* Added a new boolean input parameter `setup_portaudio` (default: `true`) to the `tests`, `docs`, and `coverage` workflows to control whether PortAudio is installed. [[1]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6R10-R14) [[2]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR15-R19) [[3]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR10-R14)
* Updated the PortAudio setup step in each workflow to only run if `setup_portaudio` is `true`. [[1]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6R34) [[2]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR44) [[3]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR36)

**Documentation updates:**

* Updated `README.md` to document the new `setup_portaudio` input, including an example of how to disable PortAudio installation for repositories that do not need it.